### PR TITLE
refactor: Rename 'type' to 'category'

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Vous devriez avoir affiché le mapping suivant :
  [OK]   App\Entity\Group
  [OK]   App\Entity\Item
  [OK]   App\Entity\Room
- [OK]   App\Entity\Type
+ [OK]   App\Entity\Category
  [OK]   App\Entity\User
 
 ```

--- a/project/migrations/Version20230403091204.php
+++ b/project/migrations/Version20230403091204.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20230403091204 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE item DROP FOREIGN KEY FK_1F1B251E5401248B');
+        $this->addSql('CREATE TABLE category (id INT AUTO_INCREMENT NOT NULL, image LONGBLOB DEFAULT NULL, description LONGTEXT DEFAULT NULL, price DOUBLE PRECISION NOT NULL, stock INT DEFAULT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('DROP TABLE type');
+        $this->addSql('DROP INDEX IDX_1F1B251E5401248B ON item');
+        $this->addSql('ALTER TABLE item CHANGE type_of_id category_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE item ADD CONSTRAINT FK_1F1B251E12469DE2 FOREIGN KEY (category_id) REFERENCES category (id)');
+        $this->addSql('CREATE INDEX IDX_1F1B251E12469DE2 ON item (category_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE item DROP FOREIGN KEY FK_1F1B251E12469DE2');
+        $this->addSql('CREATE TABLE type (id INT AUTO_INCREMENT NOT NULL, image LONGBLOB DEFAULT NULL, description LONGTEXT CHARACTER SET utf8mb4 DEFAULT NULL COLLATE `utf8mb4_unicode_ci`, price DOUBLE PRECISION NOT NULL, stock INT DEFAULT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB COMMENT = \'\' ');
+        $this->addSql('DROP TABLE category');
+        $this->addSql('DROP INDEX IDX_1F1B251E12469DE2 ON item');
+        $this->addSql('ALTER TABLE item CHANGE category_id type_of_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE item ADD CONSTRAINT FK_1F1B251E5401248B FOREIGN KEY (type_of_id) REFERENCES type (id) ON UPDATE NO ACTION ON DELETE NO ACTION');
+        $this->addSql('CREATE INDEX IDX_1F1B251E5401248B ON item (type_of_id)');
+    }
+}

--- a/project/src/Entity/Category.php
+++ b/project/src/Entity/Category.php
@@ -2,13 +2,13 @@
 
 namespace App\Entity;
 
-use App\Repository\TypeRepository;
+use App\Repository\CategoryRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
-#[ORM\Entity(repositoryClass: TypeRepository::class)]
-class Type
+#[ORM\Entity(repositoryClass: CategoryRepository::class)]
+class Category
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
@@ -27,7 +27,7 @@ class Type
     #[ORM\Column(type: 'integer', nullable: true)]
     private $stock;
 
-    #[ORM\OneToMany(mappedBy: 'typeOf', targetEntity: Item::class)]
+    #[ORM\OneToMany(mappedBy: 'category', targetEntity: Item::class)]
     private Collection $items;
 
     public function __construct()
@@ -100,7 +100,7 @@ class Type
     {
         if (!$this->items->contains($item)) {
             $this->items->add($item);
-            $item->setTypeOf($this);
+            $item->setCategory($this);
         }
 
         return $this;
@@ -110,8 +110,8 @@ class Type
     {
         if ($this->items->removeElement($item)) {
             // set the owning side to null (unless already changed)
-            if ($item->getTypeOf() === $this) {
-                $item->setTypeOf(null);
+            if ($item->getCategory() === $this) {
+                $item->setCategory(null);
             }
         }
 

--- a/project/src/Entity/Item.php
+++ b/project/src/Entity/Item.php
@@ -21,18 +21,14 @@ class Item
     #[ORM\Column(type: 'string', length: 100)]
     private $state;
 
-    #[ORM\OneToMany(mappedBy: 'item', targetEntity: Type::class)]
-    private $type;
-
     #[ORM\ManyToMany(targetEntity: Borrow::class, inversedBy: 'items')]
     private Collection $borrow;
 
     #[ORM\ManyToOne(inversedBy: 'items')]
-    private ?Type $typeOf = null;
+    private ?Category $category = null;
 
     public function __construct()
     {
-        $this->type = new ArrayCollection();
         $this->borrow = new ArrayCollection();
     }
 
@@ -90,14 +86,14 @@ class Item
         return $this;
     }
 
-    public function getTypeOf(): ?Type
+    public function getCategory(): ?Category
     {
-        return $this->typeOf;
+        return $this->category;
     }
 
-    public function setTypeOf(?Type $typeOf): self
+    public function setCategory(?Category $category): self
     {
-        $this->typeOf = $typeOf;
+        $this->category = $category;
 
         return $this;
     }

--- a/project/src/Repository/CategoryRepository.php
+++ b/project/src/Repository/CategoryRepository.php
@@ -2,26 +2,26 @@
 
 namespace App\Repository;
 
-use App\Entity\Type;
+use App\Entity\Category;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
- * @extends ServiceEntityRepository<Type>
+ * @extends ServiceEntityRepository<Category>
  *
- * @method Type|null find($id, $lockMode = null, $lockVersion = null)
- * @method Type|null findOneBy(array $criteria, array $orderBy = null)
- * @method Type[]    findAll()
- * @method Type[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ * @method Category|null find($id, $lockMode = null, $lockVersion = null)
+ * @method Category|null findOneBy(array $criteria, array $orderBy = null)
+ * @method Category[]    findAll()
+ * @method Category[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
  */
-class TypeRepository extends ServiceEntityRepository
+class CategoryRepository extends ServiceEntityRepository
 {
     public function __construct(ManagerRegistry $registry)
     {
-        parent::__construct($registry, Type::class);
+        parent::__construct($registry, Category::class);
     }
 
-    public function add(Type $entity, bool $flush = false): void
+    public function add(Category $entity, bool $flush = false): void
     {
         $this->getEntityManager()->persist($entity);
 
@@ -30,7 +30,7 @@ class TypeRepository extends ServiceEntityRepository
         }
     }
 
-    public function remove(Type $entity, bool $flush = false): void
+    public function remove(Category $entity, bool $flush = false): void
     {
         $this->getEntityManager()->remove($entity);
 
@@ -40,7 +40,7 @@ class TypeRepository extends ServiceEntityRepository
     }
 
 //    /**
-//     * @return Type[] Returns an array of Type objects
+//     * @return Category[] Returns an array of Category objects
 //     */
 //    public function findByExampleField($value): array
 //    {
@@ -54,7 +54,7 @@ class TypeRepository extends ServiceEntityRepository
 //        ;
 //    }
 
-//    public function findOneBySomeField($value): ?Type
+//    public function findOneBySomeField($value): ?Category
 //    {
 //        return $this->createQueryBuilder('t')
 //            ->andWhere('t.exampleField = :val')


### PR DESCRIPTION
Changes all mentions on the application's side of item's type to category.

This prevents confusion with Symfony's own use of 'type'.

Closes #31.