### PR TITLE
Fix #54: Restore object creation functionality

### DIFF
--- a/project/src/Controller/CategoryController.php
+++ b/project/src/Controller/CategoryController.php
@@ -23,14 +23,6 @@ class CategoryController extends AbstractController
         ]);
     }
 
-    #[Route('/category/{id}', name: 'app_view_category')]
-    public function view(Category $category): Response
-    {
-        return $this->render('category/view.html.twig', [
-            "category" => $category,
-        ]);
-    }
-
     #[Route('/category/add', name: 'app_add_category')]
     public function add(Request $request, ManagerRegistry $doctrine): Response
     {
@@ -49,6 +41,14 @@ class CategoryController extends AbstractController
 
         return $this->renderForm('category/add.html.twig', [
             'form' => $form,
+        ]);
+    }
+
+    #[Route('/category/{id}', name: 'app_view_category', requirements: ['id' => '\d+'])]
+    public function view(Category $category): Response
+    {
+        return $this->render('category/view.html.twig', [
+            "category" => $category,
         ]);
     }
 }

--- a/project/src/Controller/ItemController.php
+++ b/project/src/Controller/ItemController.php
@@ -23,13 +23,6 @@ class ItemController extends AbstractController
         ]);
     }
 
-    #[Route('/item/{id}', name: 'app_view_item')]
-    public function view(Item $item): Response
-    {
-        return $this->render('item/view.html.twig', [
-            "item" => $item,
-        ]);
-    }
 
     #[Route('/item/add', name: 'app_add_item')]
     public function add(Request $request, ManagerRegistry $doctrine): Response
@@ -48,6 +41,14 @@ class ItemController extends AbstractController
 
         return $this->renderForm('item/add.html.twig', [
             "form" => $form,
+        ]);
+    }
+
+    #[Route('/item/{id}', name: 'app_view_item', requirements: ['id' => '\d+'])]
+    public function view(Item $item): Response
+    {
+        return $this->render('item/view.html.twig', [
+            "item" => $item,
         ]);
     }
 }


### PR DESCRIPTION
Allows back the creation of items and categories.

Re-prioritises the `<type>/add` route over `<type>/{id}` by moving the latter below in the file, making the matching algorithm use the correct route for `/add` URIs. `<type>/add` will now be correctly used for matching queries instead of trying to interpret it as an ID.

Ensures on top that only numeric IDs will be used for object display by adding a type constraint.