### PR TITLE
Feature #13: Add item search

### DIFF
--- a/project/src/Controller/UnifiedSearchController.php
+++ b/project/src/Controller/UnifiedSearchController.php
@@ -2,7 +2,9 @@
 
 namespace App\Controller;
 
+use App\Entity\Item;
 use App\Form\UnifiedSearchType;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
@@ -11,10 +13,30 @@ use Symfony\Component\Routing\Annotation\Route;
 class UnifiedSearchController extends AbstractController
 {
     #[Route('/search', name: 'app_unified_search')]
-    public function index(Request $request): Response
+    public function index(Request $request, ManagerRegistry $doctrine): Response
     {
         $form = $this->createForm(UnifiedSearchType::class);
         $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $searched_name = $form->get('query')->getData();
+            $search_results = [];
+
+            switch ($form->get("criterion")->getData()) {
+                case "auto":
+                    $search_results = $doctrine->getRepository(Item::class)->findByDefaultMatch($searched_name);
+                    break;
+
+                default:
+                    throw new \Exception("Unknow criterion selected.", 1);
+            }
+
+            return $this->renderForm('unified_search/index.html.twig', [
+                'controller_name' => 'UnifiedSearchController',
+                'form' => $form,
+                "results" => $search_results,
+            ]);
+        }
 
         return $this->renderForm('unified_search/index.html.twig', [
             'controller_name' => 'UnifiedSearchController',

--- a/project/src/Controller/UnifiedSearchController.php
+++ b/project/src/Controller/UnifiedSearchController.php
@@ -24,7 +24,18 @@ class UnifiedSearchController extends AbstractController
 
             switch ($form->get("criterion")->getData()) {
                 case "auto":
-                    $search_results = $doctrine->getRepository(Item::class)->findByDefaultMatch($searched_name);
+                    $search_results = $doctrine->getRepository(Item::class)
+                        ->findByDefaultMatch($searched_name);
+                    break;
+
+                case "item":
+                    $search_results = $doctrine->getRepository(Item::class)
+                        ->findByNameMatch($searched_name);
+                    break;
+
+                case "cat":
+                    $search_results = $doctrine->getRepository(Item::class)
+                        ->findByCategoryMatch($searched_name);
                     break;
 
                 default:

--- a/project/src/Controller/UnifiedSearchController.php
+++ b/project/src/Controller/UnifiedSearchController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Controller;
+
+use App\Form\UnifiedSearchType;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+class UnifiedSearchController extends AbstractController
+{
+    #[Route('/search', name: 'app_unified_search')]
+    public function index(Request $request): Response
+    {
+        $form = $this->createForm(UnifiedSearchType::class);
+        $form->handleRequest($request);
+
+        return $this->renderForm('unified_search/index.html.twig', [
+            'controller_name' => 'UnifiedSearchController',
+            'form' => $form,
+        ]);
+    }
+}

--- a/project/src/Form/UnifiedSearchType.php
+++ b/project/src/Form/UnifiedSearchType.php
@@ -15,9 +15,11 @@ class UnifiedSearchType extends AbstractType
         $builder
             ->add("criterion", ChoiceType::class, [
                 "choices" => [
-                    "Automatique" => "auto",
-                    "Item" => "item",
-                    "Catégorie" => "cat",
+                    "Critère de recherche" => [
+                        "Automatique" => "auto",
+                        "Item" => "item",
+                        "Catégorie" => "cat",
+                    ],
                 ],
             ])
             ->add("query", SearchType::class)

--- a/project/src/Form/UnifiedSearchType.php
+++ b/project/src/Form/UnifiedSearchType.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\SearchType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class UnifiedSearchType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add("criterion", ChoiceType::class, [
+                "choices" => [
+                    "Automatique" => "auto",
+                    "Item" => "item",
+                    "Catégorie" => "cat",
+                ],
+            ])
+            ->add("query", SearchType::class)
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            // Configure your form options here
+        ]);
+    }
+}

--- a/project/src/Repository/ItemRepository.php
+++ b/project/src/Repository/ItemRepository.php
@@ -39,6 +39,22 @@ class ItemRepository extends ServiceEntityRepository
         }
     }
 
+    public function findByDefaultMatch(string $name): array
+    {
+        $entityManager = $this->getEntityManager();
+
+        $query = $entityManager->createQuery(
+            "SELECT i
+            FROM App\Entity\Item i
+            INNER JOIN App\Entity\Category c
+            WITH i.category = c.id
+            WHERE i.name LIKE :name
+            OR c.name LIKE :name"
+        )->setParameter("name", "%" . $name . "%");
+
+        return $query->getResult();
+    }
+
 //    /**
 //     * @return Item[] Returns an array of Item objects
 //     */

--- a/project/src/Repository/ItemRepository.php
+++ b/project/src/Repository/ItemRepository.php
@@ -55,6 +55,34 @@ class ItemRepository extends ServiceEntityRepository
         return $query->getResult();
     }
 
+    public function findByNameMatch(string $name): array
+    {
+        $entityManager = $this->getEntityManager();
+
+        $query = $entityManager->createQuery(
+            "SELECT i
+            FROM App\Entity\Item i
+            WHERE i.name LIKE :name"
+        )->setParameter("name", "%" . $name . "%");
+
+        return $query->getResult();
+    }
+
+    public function findByCategoryMatch(string $name): array
+    {
+        $entityManager = $this->getEntityManager();
+
+        $query = $entityManager->createQuery(
+            "SELECT i
+            FROM App\Entity\Item i
+            INNER JOIN App\Entity\Category c
+            WITH i.category = c.id
+            WHERE c.name LIKE :name"
+        )->setParameter("name", "%" . $name . "%");
+
+        return $query->getResult();
+    }
+
 //    /**
 //     * @return Item[] Returns an array of Item objects
 //     */

--- a/project/src/Repository/ItemRepository.php
+++ b/project/src/Repository/ItemRepository.php
@@ -39,6 +39,13 @@ class ItemRepository extends ServiceEntityRepository
         }
     }
 
+    /**
+     * Finds all items whose name or category name contains
+     * the searched string.
+     *
+     * @param string $name The searched string
+     * @return array An array of matching items
+     */
     public function findByDefaultMatch(string $name): array
     {
         $entityManager = $this->getEntityManager();
@@ -55,6 +62,12 @@ class ItemRepository extends ServiceEntityRepository
         return $query->getResult();
     }
 
+    /**
+     * Finds all items whose name contains the searched string.
+     *
+     * @param string $name The searched string
+     * @return array An array of matching items
+     */
     public function findByNameMatch(string $name): array
     {
         $entityManager = $this->getEntityManager();
@@ -68,6 +81,12 @@ class ItemRepository extends ServiceEntityRepository
         return $query->getResult();
     }
 
+    /**
+     * Finds all items whose category name contains the searched string.
+     *
+     * @param string $name The searched string
+     * @return array An array of matching items
+     */
     public function findByCategoryMatch(string $name): array
     {
         $entityManager = $this->getEntityManager();

--- a/project/templates/item/_item_list.html.twig
+++ b/project/templates/item/_item_list.html.twig
@@ -1,0 +1,9 @@
+{# Item list fragment #}
+
+<div>
+{% for item in items_list %}
+    <div>
+        <p><a href="/item/{{ item.id }}">{{ item.name }}</a> ({{ item.category.name }}, {{ item.state.value }})</p>
+    </div>
+{% endfor %}
+</div>

--- a/project/templates/item/index.html.twig
+++ b/project/templates/item/index.html.twig
@@ -11,13 +11,6 @@
 <div class="example-wrapper">
     <h1>Objets</h1>
 
-    <div>
-    {% for item in items %}
-        <div>
-            <p><a href="/item/{{ item.id }}" >{{ item.name }}</a> ({{ item.category.name }}, {{ item.state.value }})</p>
-        </div>
-    {% endfor %}
-    </div>
-
+    {{ include('item/_item_list.html.twig', {items_list: items}) }}
 </div>
 {% endblock %}

--- a/project/templates/unified_search/index.html.twig
+++ b/project/templates/unified_search/index.html.twig
@@ -15,5 +15,15 @@
         {{ form_widget(form) }}
         <input type="submit" value="Rechercher">
     {{ form_end(form) }}
+
+    {% if results is defined %}
+        <div>
+        {% for item in results %}
+            <div>
+                <p><a href="/item/{{ item.id }}" >{{ item.name }}</a> ({{ item.category.name }}, {{ item.state.value }})</p>
+            </div>
+        {% endfor %}
+        </div>
+    {% endif %}
 </div>
 {% endblock %}

--- a/project/templates/unified_search/index.html.twig
+++ b/project/templates/unified_search/index.html.twig
@@ -17,6 +17,9 @@
     {{ form_end(form) }}
 
     {% if results is defined %}
+        {% if results|length == 0 %}
+        <p>No results found for this query.</p>
+        {% endif %}
         <div>
         {% for item in results %}
             <div>

--- a/project/templates/unified_search/index.html.twig
+++ b/project/templates/unified_search/index.html.twig
@@ -1,0 +1,19 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Search{% endblock %}
+
+{% block body %}
+<style>
+    .example-wrapper { margin: 1em auto; max-width: 800px; width: 95%; font: 18px/1.5 sans-serif; }
+    .example-wrapper code { background: #F5F5F5; padding: 2px 6px; }
+</style>
+
+<div class="example-wrapper">
+    <h1>Search</h1>
+
+    {{ form_start(form) }}
+        {{ form_widget(form) }}
+        <input type="submit" value="Rechercher">
+    {{ form_end(form) }}
+</div>
+{% endblock %}

--- a/project/templates/unified_search/index.html.twig
+++ b/project/templates/unified_search/index.html.twig
@@ -18,7 +18,7 @@
 
     {% if results is defined %}
         {% if results|length == 0 %}
-        <p>No results found for this query.</p>
+        <p>Aucun résultat pour le terme cherché.</p>
         {% endif %}
     {{ include('item/_item_list.html.twig', {items_list: results}) }}
     {% endif %}

--- a/project/templates/unified_search/index.html.twig
+++ b/project/templates/unified_search/index.html.twig
@@ -20,13 +20,8 @@
         {% if results|length == 0 %}
         <p>No results found for this query.</p>
         {% endif %}
-        <div>
-        {% for item in results %}
-            <div>
-                <p><a href="/item/{{ item.id }}" >{{ item.name }}</a> ({{ item.category.name }}, {{ item.state.value }})</p>
-            </div>
-        {% endfor %}
-        </div>
+    {{ include('item/_item_list.html.twig', {items_list: results}) }}
     {% endif %}
+
 </div>
 {% endblock %}


### PR DESCRIPTION
Creates a new page with a search form at `/search`. The results appear on the same page.

A drop-down menu allows to select different search criteria. The default one searches among item names and their category name.

The item display is a copy of what is on the `/item` page.