### PR TITLE
Fix #71 : Improve reservation creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .history
+*.bak

--- a/doc/explications/diagramme-bdd.svg
+++ b/doc/explications/diagramme-bdd.svg
@@ -1,861 +1,730 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="1169px" height="827px" version="1.1" viewBox="-.5 -.5 1169 827" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:xhtml="http://www.w3.org/1999/xhtml">
-	<metadata>
-		<rdf:RDF>
-			<cc:Work rdf:about="">
-				<dc:format>image/svg+xml</dc:format>
-				<dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-				<dc:title/>
-			</cc:Work>
-		</rdf:RDF>
-	</metadata>
-	<rect x="-.5" y="-.5" width="1169" height="827" fill="#fff" stop-color="#000000" stroke-linecap="round" stroke-miterlimit="3.8662" stroke-width="2" style="paint-order:stroke markers fill"/>
-	<path d="m50 519v-30h180v30" fill="#fff" pointer-events="all" stroke="#000" stroke-miterlimit="10"/>
-	<g fill="none" pointer-events="none" stroke="#000" stroke-miterlimit="10">
-		<path d="m50 519v180h180v-180"/>
-		<path d="m50 519h180"/>
-		<path d="m80 519v180"/>
-	</g>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe center;margin-left:140px;padding-top:504px;width:1px">
-					<xhtml:div font-size="0px" text-align="center" style="box-sizing:border-box" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" font-weight="bold" pointer-events="none" style="line-height:1.2;white-space:nowrap">Category</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="140" y="508" fill="#000000" font-family="Helvetica" font-size="12px" font-weight="bold" text-anchor="middle">Category</text>
-		</switch>
-	</g>
-	<path d="m50 519m180 0m0 30h-180" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<path d="m50 519m30 0m0 30m-30 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe center;margin-left:51px;padding-top:534px;width:28px">
-					<xhtml:div font-size="0px" text-align="center" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" font-weight="bold" pointer-events="none" style="line-height:1.2;overflow-wrap:normal;white-space:normal">PK</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="65" y="538" fill="#000000" font-family="Helvetica" font-size="12px" font-weight="bold" text-anchor="middle">PK</text>
-		</switch>
-	</g>
-	<path d="m80 519m150 0m0 30m-150 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe flex-start;margin-left:88px;padding-top:534px;width:142px">
-					<xhtml:div font-size="0px" text-align="left" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" font-weight="bold" pointer-events="none" text-decoration="underline" style="line-height:1.2;overflow-wrap:normal;white-space:normal">id</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="88" y="538" fill="#000000" font-family="Helvetica" font-size="12px" font-weight="bold" text-decoration="underline" style="text-decoration-line:underline">id</text>
-		</switch>
-	</g>
-	<path d="m50 549m30 0m0 30m-30 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<path d="m80 549m150 0m0 30m-150 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe flex-start;margin-left:88px;padding-top:564px;width:142px">
-					<xhtml:div font-size="0px" text-align="left" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" pointer-events="none" style="line-height:1.2;overflow-wrap:normal;white-space:normal">image</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="88" y="568" fill="#000000" font-family="Helvetica" font-size="12px">image</text>
-		</switch>
-	</g>
-	<path d="m50 579m30 0m0 30m-30 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<path d="m80 579m150 0m0 30m-150 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe flex-start;margin-left:88px;padding-top:594px;width:142px">
-					<xhtml:div font-size="0px" text-align="left" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" pointer-events="none" style="line-height:1.2;overflow-wrap:normal;white-space:normal">description</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="88" y="598" fill="#000000" font-family="Helvetica" font-size="12px">description</text>
-		</switch>
-	</g>
-	<path d="m50 609m30 0m0 30m-30 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<path d="m80 609m150 0m0 30m-150 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe flex-start;margin-left:88px;padding-top:624px;width:142px">
-					<xhtml:div font-size="0px" text-align="left" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" pointer-events="none" style="line-height:1.2;overflow-wrap:normal;white-space:normal">price</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="88" y="628" fill="#000000" font-family="Helvetica" font-size="12px">price</text>
-		</switch>
-	</g>
-	<path d="m50 639m30 0m0 30m-30 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<path d="m80 639m150 0m0 30m-150 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe flex-start;margin-left:88px;padding-top:654px;width:142px">
-					<xhtml:div font-size="0px" text-align="left" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" pointer-events="none" style="line-height:1.2;overflow-wrap:normal;white-space:normal">stock</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="88" y="658" fill="#000000" font-family="Helvetica" font-size="12px">stock</text>
-		</switch>
-	</g>
-	<path d="m50 669m30 0m0 30m-30 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<path d="m80 669m150 0m0 30m-150 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe flex-start;margin-left:88px;padding-top:684px;width:142px">
-					<xhtml:div font-size="0px" text-align="left" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" pointer-events="none" style="line-height:1.2;overflow-wrap:normal;white-space:normal">name</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="88" y="688" fill="#000000" font-family="Helvetica" font-size="12px">name</text>
-		</switch>
-	</g>
-	<path d="m435 248v-30h180v30" fill="#fff" pointer-events="none" stroke="#000" stroke-miterlimit="10"/>
-	<g fill="none" pointer-events="none" stroke="#000" stroke-miterlimit="10">
-		<path d="m435 248v300h180v-300"/>
-		<path d="m435 248h180"/>
-		<path d="m465 248v300"/>
-	</g>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe center;margin-left:525px;padding-top:233px;width:1px">
-					<xhtml:div font-size="0px" text-align="center" style="box-sizing:border-box" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" font-weight="bold" pointer-events="none" style="line-height:1.2;white-space:nowrap">Borrow</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="525" y="237" fill="#000000" font-family="Helvetica" font-size="12px" font-weight="bold" text-anchor="middle">Borrow</text>
-		</switch>
-	</g>
-	<path d="m435 248m180 0m0 30h-180" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<path d="m435 248m30 0m0 30m-30 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe center;margin-left:436px;padding-top:263px;width:28px">
-					<xhtml:div font-size="0px" text-align="center" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" font-weight="bold" pointer-events="none" style="line-height:1.2;overflow-wrap:normal;white-space:normal">PK</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="450" y="267" fill="#000000" font-family="Helvetica" font-size="12px" font-weight="bold" text-anchor="middle">PK</text>
-		</switch>
-	</g>
-	<path d="m465 248m150 0m0 30m-150 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe flex-start;margin-left:473px;padding-top:263px;width:142px">
-					<xhtml:div font-size="0px" text-align="left" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" font-weight="bold" pointer-events="none" text-decoration="underline" style="line-height:1.2;overflow-wrap:normal;white-space:normal">id</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="473" y="267" fill="#000000" font-family="Helvetica" font-size="12px" font-weight="bold" text-decoration="underline" style="text-decoration-line:underline">id</text>
-		</switch>
-	</g>
-	<path d="m435 278m30 0m0 30m-30 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe center;margin-left:436px;padding-top:293px;width:28px">
-					<xhtml:div font-size="0px" text-align="center" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" pointer-events="none" style="line-height:1.2;overflow-wrap:normal;white-space:normal">FK</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="450" y="297" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">FK</text>
-		</switch>
-	</g>
-	<path d="m465 278m150 0m0 30m-150 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe flex-start;margin-left:473px;padding-top:293px;width:142px">
-					<xhtml:div font-size="0px" text-align="left" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" pointer-events="none" style="line-height:1.2;overflow-wrap:normal;white-space:normal">stakeholder_id</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="473" y="297" fill="#000000" font-family="Helvetica" font-size="12px">stakeholder_id</text>
-		</switch>
-	</g>
-	<path d="m435 308m30 0m0 30m-30 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe center;margin-left:436px;padding-top:323px;width:28px">
-					<xhtml:div font-size="0px" text-align="center" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" pointer-events="none" style="line-height:1.2;overflow-wrap:normal;white-space:normal">FK</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="450" y="327" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">FK</text>
-		</switch>
-	</g>
-	<path d="m465 308m150 0m0 30m-150 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe flex-start;margin-left:473px;padding-top:323px;width:142px">
-					<xhtml:div font-size="0px" text-align="left" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" pointer-events="none" style="line-height:1.2;overflow-wrap:normal;white-space:normal">room_id</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="473" y="327" fill="#000000" font-family="Helvetica" font-size="12px">room_id</text>
-		</switch>
-	</g>
-	<path d="m435 338m30 0m0 30m-30 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe center;margin-left:436px;padding-top:353px;width:28px">
-					<xhtml:div font-size="0px" text-align="center" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" pointer-events="none" style="line-height:1.2;overflow-wrap:normal;white-space:normal">FK</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="450" y="357" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">FK</text>
-		</switch>
-	</g>
-	<path d="m465 338m150 0m0 30m-150 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe flex-start;margin-left:473px;padding-top:353px;width:142px">
-					<xhtml:div font-size="0px" text-align="left" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" pointer-events="none" style="line-height:1.2;overflow-wrap:normal;white-space:normal">team_id</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="473" y="357" fill="#000000" font-family="Helvetica" font-size="12px">team_id</text>
-		</switch>
-	</g>
-	<path d="m435 368m30 0m0 30m-30 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<path d="m465 368m150 0m0 30m-150 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe flex-start;margin-left:473px;padding-top:383px;width:142px">
-					<xhtml:div font-size="0px" text-align="left" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" pointer-events="none" style="line-height:1.2;overflow-wrap:normal;white-space:normal">start_date</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="473" y="387" fill="#000000" font-family="Helvetica" font-size="12px">start_date</text>
-		</switch>
-	</g>
-	<path d="m435 398m30 0m0 30m-30 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<path d="m465 398m150 0m0 30m-150 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe flex-start;margin-left:473px;padding-top:413px;width:142px">
-					<xhtml:div font-size="0px" text-align="left" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" pointer-events="none" style="line-height:1.2;overflow-wrap:normal;white-space:normal">end_date</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="473" y="417" fill="#000000" font-family="Helvetica" font-size="12px">end_date</text>
-		</switch>
-	</g>
-	<path d="m435 428m30 0m0 30m-30 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<path d="m465 428m150 0m0 30m-150 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe flex-start;margin-left:473px;padding-top:443px;width:142px">
-					<xhtml:div font-size="0px" text-align="left" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" pointer-events="none" style="line-height:1.2;overflow-wrap:normal;white-space:normal">description</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="473" y="447" fill="#000000" font-family="Helvetica" font-size="12px">description</text>
-		</switch>
-	</g>
-	<path d="m435 458m30 0m0 30m-30 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<path d="m465 458m150 0m0 30m-150 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe flex-start;margin-left:473px;padding-top:473px;width:142px">
-					<xhtml:div font-size="0px" text-align="left" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" pointer-events="none" style="line-height:1.2;overflow-wrap:normal;white-space:normal">return_description</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="473" y="477" fill="#000000" font-family="Helvetica" font-size="12px">return_description</text>
-		</switch>
-	</g>
-	<path d="m435 488m30 0m0 30m-30 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<path d="m465 488m150 0m0 30m-150 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe flex-start;margin-left:473px;padding-top:503px;width:142px">
-					<xhtml:div font-size="0px" text-align="left" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" pointer-events="none" style="line-height:1.2;overflow-wrap:normal;white-space:normal">restituted</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="473" y="507" fill="#000000" font-family="Helvetica" font-size="12px">restituted</text>
-		</switch>
-	</g>
-	<path d="m435 518m30 0m0 30m-30 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<path d="m465 518m150 0m0 30m-150 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe flex-start;margin-left:473px;padding-top:533px;width:142px">
-					<xhtml:div font-size="0px" text-align="left" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" pointer-events="none" style="line-height:1.2;overflow-wrap:normal;white-space:normal">quantity</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="473" y="537" fill="#000000" font-family="Helvetica" font-size="12px">quantity</text>
-		</switch>
-	</g>
-	<path d="m200 149v-30h180v30" fill="#fff" pointer-events="none" stroke="#000" stroke-miterlimit="10"/>
-	<g fill="none" pointer-events="none" stroke="#000" stroke-miterlimit="10">
-		<path d="m200 149v60h180v-60"/>
-		<path d="m200 149h180"/>
-		<path d="m260 149v60"/>
-	</g>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe center;margin-left:201px;padding-top:134px;width:178px">
-					<xhtml:div font-size="0px" text-align="center" style="box-sizing:border-box" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" font-weight="bold" pointer-events="none" style="line-height:1.2;overflow-wrap:normal;white-space:normal">Item-Borrow</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="290" y="138" fill="#000000" font-family="Helvetica" font-size="12px" font-weight="bold" text-anchor="middle">Item-Borrow</text>
-		</switch>
-	</g>
-	<path d="m200 149m60 0m0 30m-60 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe center;margin-left:201px;padding-top:164px;width:58px">
-					<xhtml:div font-size="0px" text-align="center" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" font-weight="bold" pointer-events="none" style="line-height:1.2;overflow-wrap:normal;white-space:normal">PK,FK1</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="230" y="168" fill="#000000" font-family="Helvetica" font-size="12px" font-weight="bold" text-anchor="middle">PK,FK1</text>
-		</switch>
-	</g>
-	<path d="m260 149m120 0m0 30m-120 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe flex-start;margin-left:268px;padding-top:164px;width:112px">
-					<xhtml:div font-size="0px" text-align="left" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" font-weight="bold" pointer-events="none" text-decoration="underline" style="line-height:1.2;overflow-wrap:normal;white-space:normal">item_id</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="268" y="168" fill="#000000" font-family="Helvetica" font-size="12px" font-weight="bold" text-decoration="underline" style="text-decoration-line:underline">item_id</text>
-		</switch>
-	</g>
-	<path d="m200 179m180 0m0 30h-180" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<path d="m200 179m60 0m0 30m-60 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe center;margin-left:201px;padding-top:194px;width:58px">
-					<xhtml:div font-size="0px" text-align="center" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" font-weight="bold" pointer-events="none" style="line-height:1.2;overflow-wrap:normal;white-space:normal">PK,FK2</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="230" y="198" fill="#000000" font-family="Helvetica" font-size="12px" font-weight="bold" text-anchor="middle">PK,FK2</text>
-		</switch>
-	</g>
-	<path d="m260 179m120 0m0 30m-120 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe flex-start;margin-left:268px;padding-top:194px;width:112px">
-					<xhtml:div font-size="0px" text-align="left" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" font-weight="bold" pointer-events="none" text-decoration="underline" style="line-height:1.2;overflow-wrap:normal;white-space:normal">borrow_id</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="268" y="198" fill="#000000" font-family="Helvetica" font-size="12px" font-weight="bold" text-decoration="underline" style="text-decoration-line:underline">borrow_id</text>
-		</switch>
-	</g>
-	<path d="m50 289v-30h180v30" fill="#fff" pointer-events="none" stroke="#000" stroke-miterlimit="10"/>
-	<g fill="none" pointer-events="none" stroke="#000" stroke-miterlimit="10">
-		<path d="m50 289v120h180v-120"/>
-		<path d="m50 289h180"/>
-		<path d="m80 289v120"/>
-	</g>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe center;margin-left:140px;padding-top:274px;width:1px">
-					<xhtml:div font-size="0px" text-align="center" style="box-sizing:border-box" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" font-weight="bold" pointer-events="none" style="line-height:1.2;white-space:nowrap">Item</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="140" y="278" fill="#000000" font-family="Helvetica" font-size="12px" font-weight="bold" text-anchor="middle">Item</text>
-		</switch>
-	</g>
-	<path d="m50 289m180 0m0 30h-180" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<path d="m50 289m30 0m0 30m-30 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe center;margin-left:51px;padding-top:304px;width:28px">
-					<xhtml:div font-size="0px" text-align="center" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" font-weight="bold" pointer-events="none" style="line-height:1.2;overflow-wrap:normal;white-space:normal">PK</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="65" y="308" fill="#000000" font-family="Helvetica" font-size="12px" font-weight="bold" text-anchor="middle">PK</text>
-		</switch>
-	</g>
-	<path d="m80 289m150 0m0 30m-150 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe flex-start;margin-left:88px;padding-top:304px;width:142px">
-					<xhtml:div font-size="0px" text-align="left" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" font-weight="bold" pointer-events="none" text-decoration="underline" style="line-height:1.2;overflow-wrap:normal;white-space:normal">id</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="88" y="308" fill="#000000" font-family="Helvetica" font-size="12px" font-weight="bold" text-decoration="underline" style="text-decoration-line:underline">id</text>
-		</switch>
-	</g>
-	<path d="m50 319m30 0m0 30m-30 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe center;margin-left:51px;padding-top:334px;width:28px">
-					<xhtml:div font-size="0px" text-align="center" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" pointer-events="none" style="line-height:1.2;overflow-wrap:normal;white-space:normal">FK</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="65" y="338" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">FK</text>
-		</switch>
-	</g>
-	<path d="m80 319m150 0m0 30m-150 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe flex-start;margin-left:88px;padding-top:334px;width:142px">
-					<xhtml:div font-size="0px" text-align="left" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" pointer-events="none" style="line-height:1.2;overflow-wrap:normal;white-space:normal">category_id</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="88" y="338" fill="#000000" font-family="Helvetica" font-size="12px">category_id</text>
-		</switch>
-	</g>
-	<path d="m50 349m30 0m0 30m-30 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<path d="m80 349m150 0m0 30m-150 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe flex-start;margin-left:88px;padding-top:364px;width:142px">
-					<xhtml:div font-size="0px" text-align="left" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" pointer-events="none" style="line-height:1.2;overflow-wrap:normal;white-space:normal">name</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="88" y="368" fill="#000000" font-family="Helvetica" font-size="12px">name</text>
-		</switch>
-	</g>
-	<path d="m50 379m30 0m0 30m-30 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<path d="m80 379m150 0m0 30m-150 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe flex-start;margin-left:88px;padding-top:394px;width:142px">
-					<xhtml:div font-size="0px" text-align="left" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" pointer-events="none" style="line-height:1.2;overflow-wrap:normal;white-space:normal">state</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="88" y="398" fill="#000000" font-family="Helvetica" font-size="12px">state</text>
-		</switch>
-	</g>
-	<path d="m380 639v-30h180v30" fill="#fff" pointer-events="none" stroke="#000" stroke-miterlimit="10"/>
-	<g fill="none" pointer-events="none" stroke="#000" stroke-miterlimit="10">
-		<path d="m380 639v120h180v-120"/>
-		<path d="m380 639h180"/>
-		<path d="m410 639v120"/>
-	</g>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe center;margin-left:470px;padding-top:624px;width:1px">
-					<xhtml:div font-size="0px" text-align="center" style="box-sizing:border-box" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" font-weight="bold" pointer-events="none" style="line-height:1.2;white-space:nowrap">Room</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="470" y="628" fill="#000000" font-family="Helvetica" font-size="12px" font-weight="bold" text-anchor="middle">Room</text>
-		</switch>
-	</g>
-	<path d="m380 639m180 0m0 30h-180" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<path d="m380 639m30 0m0 30m-30 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe center;margin-left:381px;padding-top:654px;width:28px">
-					<xhtml:div font-size="0px" text-align="center" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" font-weight="bold" pointer-events="none" style="line-height:1.2;overflow-wrap:normal;white-space:normal">PK</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="395" y="658" fill="#000000" font-family="Helvetica" font-size="12px" font-weight="bold" text-anchor="middle">PK</text>
-		</switch>
-	</g>
-	<path d="m410 639m150 0m0 30m-150 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe flex-start;margin-left:418px;padding-top:654px;width:142px">
-					<xhtml:div font-size="0px" text-align="left" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" font-weight="bold" pointer-events="none" text-decoration="underline" style="line-height:1.2;overflow-wrap:normal;white-space:normal">id</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="418" y="658" fill="#000000" font-family="Helvetica" font-size="12px" font-weight="bold" text-decoration="underline" style="text-decoration-line:underline">id</text>
-		</switch>
-	</g>
-	<path d="m380 669m30 0m0 30m-30 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<path d="m410 669m150 0m0 30m-150 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe flex-start;margin-left:418px;padding-top:684px;width:142px">
-					<xhtml:div font-size="0px" text-align="left" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" pointer-events="none" style="line-height:1.2;overflow-wrap:normal;white-space:normal">name</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="418" y="688" fill="#000000" font-family="Helvetica" font-size="12px">name</text>
-		</switch>
-	</g>
-	<path d="m380 699m30 0m0 30m-30 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<path d="m410 699m150 0m0 30m-150 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe flex-start;margin-left:418px;padding-top:714px;width:142px">
-					<xhtml:div font-size="0px" text-align="left" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" pointer-events="none" style="line-height:1.2;overflow-wrap:normal;white-space:normal">description</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="418" y="718" fill="#000000" font-family="Helvetica" font-size="12px">description</text>
-		</switch>
-	</g>
-	<path d="m380 729m30 0m0 30m-30 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<path d="m410 729m150 0m0 30m-150 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe flex-start;margin-left:418px;padding-top:744px;width:142px">
-					<xhtml:div font-size="0px" text-align="left" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" pointer-events="none" style="line-height:1.2;overflow-wrap:normal;white-space:normal">reserved</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="418" y="748" fill="#000000" font-family="Helvetica" font-size="12px">reserved</text>
-		</switch>
-	</g>
-	<path d="m720 539v-30h180v30" fill="#fff" pointer-events="none" stroke="#000" stroke-miterlimit="10"/>
-	<g fill="none" pointer-events="none" stroke="#000" stroke-miterlimit="10">
-		<path d="m720 539v60h180v-60"/>
-		<path d="m720 539h180"/>
-		<path d="m750 539v60"/>
-	</g>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe center;margin-left:810px;padding-top:524px;width:1px">
-					<xhtml:div font-size="0px" text-align="center" style="box-sizing:border-box" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" font-weight="bold" pointer-events="none" style="line-height:1.2;white-space:nowrap">Group</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="810" y="528" fill="#000000" font-family="Helvetica" font-size="12px" font-weight="bold" text-anchor="middle">Group</text>
-		</switch>
-	</g>
-	<path d="m720 539m180 0m0 30h-180" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<path d="m720 539m30 0m0 30m-30 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe center;margin-left:721px;padding-top:554px;width:28px">
-					<xhtml:div font-size="0px" text-align="center" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" font-weight="bold" pointer-events="none" style="line-height:1.2;overflow-wrap:normal;white-space:normal">PK</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="735" y="558" fill="#000000" font-family="Helvetica" font-size="12px" font-weight="bold" text-anchor="middle">PK</text>
-		</switch>
-	</g>
-	<path d="m750 539m150 0m0 30m-150 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe flex-start;margin-left:758px;padding-top:554px;width:142px">
-					<xhtml:div font-size="0px" text-align="left" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" font-weight="bold" pointer-events="none" text-decoration="underline" style="line-height:1.2;overflow-wrap:normal;white-space:normal">id</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="758" y="558" fill="#000000" font-family="Helvetica" font-size="12px" font-weight="bold" text-decoration="underline" style="text-decoration-line:underline">id</text>
-		</switch>
-	</g>
-	<path d="m720 569m30 0m0 30m-30 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<path d="m750 569m150 0m0 30m-150 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe flex-start;margin-left:758px;padding-top:584px;width:142px">
-					<xhtml:div font-size="0px" text-align="left" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" pointer-events="none" style="line-height:1.2;overflow-wrap:normal;white-space:normal">name</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="758" y="588" fill="#000000" font-family="Helvetica" font-size="12px">name</text>
-		</switch>
-	</g>
-	<path d="m710 99v-30h180v30" fill="#fff" pointer-events="none" stroke="#000" stroke-miterlimit="10"/>
-	<g fill="none" pointer-events="none" stroke="#000" stroke-miterlimit="10">
-		<path d="m710 99v210h180v-210"/>
-		<path d="m710 99h180"/>
-		<path d="m740 99v210"/>
-	</g>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe center;margin-left:800px;padding-top:84px;width:1px">
-					<xhtml:div font-size="0px" text-align="center" style="box-sizing:border-box" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" font-weight="bold" pointer-events="none" style="line-height:1.2;white-space:nowrap">User</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="800" y="88" fill="#000000" font-family="Helvetica" font-size="12px" font-weight="bold" text-anchor="middle">User</text>
-		</switch>
-	</g>
-	<path d="m710 99m180 0m0 30h-180" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<path d="m710 99m30 0m0 30m-30 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe center;margin-left:711px;padding-top:114px;width:28px">
-					<xhtml:div font-size="0px" text-align="center" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" font-weight="bold" pointer-events="none" style="line-height:1.2;overflow-wrap:normal;white-space:normal">PK</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="725" y="118" fill="#000000" font-family="Helvetica" font-size="12px" font-weight="bold" text-anchor="middle">PK</text>
-		</switch>
-	</g>
-	<path d="m740 99m150 0m0 30m-150 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe flex-start;margin-left:748px;padding-top:114px;width:142px">
-					<xhtml:div font-size="0px" text-align="left" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" font-weight="bold" pointer-events="none" text-decoration="underline" style="line-height:1.2;overflow-wrap:normal;white-space:normal">id</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="748" y="118" fill="#000000" font-family="Helvetica" font-size="12px" font-weight="bold" text-decoration="underline" style="text-decoration-line:underline">id</text>
-		</switch>
-	</g>
-	<path d="m710 129m30 0m0 30m-30 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<path d="m740 129m150 0m0 30m-150 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe flex-start;margin-left:748px;padding-top:144px;width:142px">
-					<xhtml:div font-size="0px" text-align="left" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" pointer-events="none" style="line-height:1.2;overflow-wrap:normal;white-space:normal">email</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="748" y="148" fill="#000000" font-family="Helvetica" font-size="12px">email</text>
-		</switch>
-	</g>
-	<path d="m710 159m30 0m0 30m-30 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<path d="m740 159m150 0m0 30m-150 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe flex-start;margin-left:748px;padding-top:174px;width:142px">
-					<xhtml:div font-size="0px" text-align="left" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" pointer-events="none" style="line-height:1.2;overflow-wrap:normal;white-space:normal">roles</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="748" y="178" fill="#000000" font-family="Helvetica" font-size="12px">roles</text>
-		</switch>
-	</g>
-	<path d="m710 189m30 0m0 30m-30 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<path d="m740 189m150 0m0 30m-150 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe flex-start;margin-left:748px;padding-top:204px;width:142px">
-					<xhtml:div font-size="0px" text-align="left" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" pointer-events="none" style="line-height:1.2;overflow-wrap:normal;white-space:normal">password</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="748" y="208" fill="#000000" font-family="Helvetica" font-size="12px">password</text>
-		</switch>
-	</g>
-	<path d="m710 219m30 0m0 30m-30 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<path d="m740 219m150 0m0 30m-150 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe flex-start;margin-left:748px;padding-top:234px;width:142px">
-					<xhtml:div font-size="0px" text-align="left" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" pointer-events="none" style="line-height:1.2;overflow-wrap:normal;white-space:normal">last_naùe</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="748" y="238" fill="#000000" font-family="Helvetica" font-size="12px">last_name</text>
-		</switch>
-	</g>
-	<path d="m710 249m30 0m0 30m-30 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<path d="m740 249m150 0m0 30m-150 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe flex-start;margin-left:748px;padding-top:264px;width:142px">
-					<xhtml:div font-size="0px" text-align="left" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" pointer-events="none" style="line-height:1.2;overflow-wrap:normal;white-space:normal">first_name</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="748" y="268" fill="#000000" font-family="Helvetica" font-size="12px">first_name</text>
-		</switch>
-	</g>
-	<path d="m710 279m30 0m0 30m-30 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<path d="m740 279m150 0m0 30m-150 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe flex-start;margin-left:748px;padding-top:294px;width:142px">
-					<xhtml:div font-size="0px" text-align="left" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" pointer-events="none" style="line-height:1.2;overflow-wrap:normal;white-space:normal">is_verified</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="748" y="298" fill="#000000" font-family="Helvetica" font-size="12px">is_verified</text>
-		</switch>
-	</g>
-	<path d="m940 410v-30h180v30" fill="#fff" pointer-events="none" stroke="#000" stroke-miterlimit="10"/>
-	<g fill="none" pointer-events="none" stroke="#000" stroke-miterlimit="10">
-		<path d="m940 410v60h180v-60"/>
-		<path d="m940 410h180"/>
-		<path d="m1e3 410v60"/>
-	</g>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe center;margin-left:941px;padding-top:395px;width:178px">
-					<xhtml:div font-size="0px" text-align="center" style="box-sizing:border-box" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" font-weight="bold" pointer-events="none" style="line-height:1.2;overflow-wrap:normal;white-space:normal">Group-User</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="1030" y="399" fill="#000000" font-family="Helvetica" font-size="12px" font-weight="bold" text-anchor="middle">Group-User</text>
-		</switch>
-	</g>
-	<path d="m940 410m60 0m0 30m-60 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe center;margin-left:941px;padding-top:425px;width:58px">
-					<xhtml:div font-size="0px" text-align="center" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" font-weight="bold" pointer-events="none" style="line-height:1.2;overflow-wrap:normal;white-space:normal">PK,FK1</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="970" y="429" fill="#000000" font-family="Helvetica" font-size="12px" font-weight="bold" text-anchor="middle">PK,FK1</text>
-		</switch>
-	</g>
-	<path d="m1e3 410m120 0m0 30m-120 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe flex-start;margin-left:1008px;padding-top:425px;width:112px">
-					<xhtml:div font-size="0px" text-align="left" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" font-weight="bold" pointer-events="none" text-decoration="underline" style="line-height:1.2;overflow-wrap:normal;white-space:normal">group_id</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="1008" y="429" fill="#000000" font-family="Helvetica" font-size="12px" font-weight="bold" text-decoration="underline" style="text-decoration-line:underline">group_id</text>
-		</switch>
-	</g>
-	<path d="m940 440m180 0m0 30h-180" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<path d="m940 440m60 0m0 30m-60 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe center;margin-left:941px;padding-top:455px;width:58px">
-					<xhtml:div font-size="0px" text-align="center" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" font-weight="bold" pointer-events="none" style="line-height:1.2;overflow-wrap:normal;white-space:normal">PK,FK2</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="970" y="459" fill="#000000" font-family="Helvetica" font-size="12px" font-weight="bold" text-anchor="middle">PK,FK2</text>
-		</switch>
-	</g>
-	<path d="m1e3 440m120 0m0 30m-120 0" fill="none" pointer-events="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10"/>
-	<g transform="translate(-.5 -.5)">
-		<switch>
-			<foreignObject width="100%" height="100%" overflow="visible" pointer-events="none" text-align="left" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-				<xhtml:div display="flex" style="align-items:unsafe center;height:1px;justify-content:unsafe flex-start;margin-left:1008px;padding-top:455px;width:112px">
-					<xhtml:div font-size="0px" text-align="left" style="box-sizing:border-box;max-height:26px" data-drawio-colors="color: rgb(0, 0, 0); ">
-						<xhtml:div color="rgb(0, 0, 0)" display="inline-block" font-family="Helvetica" font-size="12px" font-weight="bold" pointer-events="none" text-decoration="underline" style="line-height:1.2;overflow-wrap:normal;white-space:normal">user_id</xhtml:div>
-					</xhtml:div>
-				</xhtml:div>
-			</foreignObject>
-			<text x="1008" y="459" fill="#000000" font-family="Helvetica" font-size="12px" font-weight="bold" text-decoration="underline" style="text-decoration-line:underline">user_id</text>
-		</switch>
-	</g>
-	<g fill="none" pointer-events="none" stroke="#000" stroke-miterlimit="10">
-		<path d="m435 323h-125v323.5h70"/>
-		<path d="m615 353h52.5v201h52.5"/>
-		<path d="m380 194h27.5v69h27.5"/>
-		<path d="m50 304h-10v-140h160"/>
-		<path d="m50 334h-10v200h10"/>
-		<path d="m1120 425h10v129h-230"/>
-		<path d="m615 293h47.5v-179h47.5"/>
-		<path d="m890 114h25v341h25"/>
-	</g>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="-1 -1 1169 827" style="background-color:#fff">
+  <path d="M50 519v-30h180v30" fill="#FFF" stroke="#000" stroke-miterlimit="10" pointer-events="all"/>
+  <path d="M50 519v180h180V519m-180 0h180m-150 0v180" fill="none" stroke="#000" stroke-miterlimit="10" pointer-events="none"/>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:504px;margin-left:140px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;font-weight:700;white-space:nowrap">
+            Category
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="140" y="508" font-family="Helvetica" font-size="12" text-anchor="middle" font-weight="bold">Category</text>
+  </switch>
+  <path d="M230 549H50m0 0" fill="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10" pointer-events="none"/>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:28px;height:1px;padding-top:534px;margin-left:51px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;font-weight:700;white-space:normal;overflow-wrap:normal">
+            PK
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="65" y="538" font-family="Helvetica" font-size="12" text-anchor="middle" font-weight="bold">PK</text>
+  </switch>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:142px;height:1px;padding-top:534px;margin-left:88px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;font-weight:700;text-decoration:underline;white-space:normal;overflow-wrap:normal">
+            id
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="88" y="538" font-family="Helvetica" font-size="12" font-weight="bold" text-decoration="underline">id</text>
+  </switch>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:142px;height:1px;padding-top:564px;margin-left:88px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+            image
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="88" y="568" font-family="Helvetica" font-size="12">image</text>
+  </switch>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:142px;height:1px;padding-top:594px;margin-left:88px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+            description
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="88" y="598" font-family="Helvetica" font-size="12">description</text>
+  </switch>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:142px;height:1px;padding-top:624px;margin-left:88px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+            price
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="88" y="628" font-family="Helvetica" font-size="12">price</text>
+  </switch>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:142px;height:1px;padding-top:654px;margin-left:88px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+            stock
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="88" y="658" font-family="Helvetica" font-size="12">stock</text>
+  </switch>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:142px;height:1px;padding-top:684px;margin-left:88px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+            name
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="88" y="688" font-family="Helvetica" font-size="12">name</text>
+  </switch>
+  <path d="M435 248v-30h180v30" fill="#FFF" stroke="#000" stroke-miterlimit="10" pointer-events="none"/>
+  <path d="M435 248v270h180V248m-180 0h180m-150 0v270" fill="none" stroke="#000" stroke-miterlimit="10" pointer-events="none"/>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:233px;margin-left:525px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;font-weight:700;white-space:nowrap">
+            Borrow
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="525" y="237" font-family="Helvetica" font-size="12" text-anchor="middle" font-weight="bold">Borrow</text>
+  </switch>
+  <path d="M615 278H435m0 0" fill="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10" pointer-events="none"/>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:28px;height:1px;padding-top:263px;margin-left:436px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;font-weight:700;white-space:normal;overflow-wrap:normal">
+            PK
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="450" y="267" font-family="Helvetica" font-size="12" text-anchor="middle" font-weight="bold">PK</text>
+  </switch>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:142px;height:1px;padding-top:263px;margin-left:473px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;font-weight:700;text-decoration:underline;white-space:normal;overflow-wrap:normal">
+            id
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="473" y="267" font-family="Helvetica" font-size="12" font-weight="bold" text-decoration="underline">id</text>
+  </switch>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:28px;height:1px;padding-top:293px;margin-left:436px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+            FK
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="450" y="297" font-family="Helvetica" font-size="12" text-anchor="middle">FK</text>
+  </switch>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:142px;height:1px;padding-top:293px;margin-left:473px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+            stakeholder_id
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="473" y="297" font-family="Helvetica" font-size="12">stakeholder_id</text>
+  </switch>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:28px;height:1px;padding-top:323px;margin-left:436px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+            FK
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="450" y="327" font-family="Helvetica" font-size="12" text-anchor="middle">FK</text>
+  </switch>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:142px;height:1px;padding-top:323px;margin-left:473px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+            room_id
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="473" y="327" font-family="Helvetica" font-size="12">room_id</text>
+  </switch>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:28px;height:1px;padding-top:353px;margin-left:436px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+            FK
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="450" y="357" font-family="Helvetica" font-size="12" text-anchor="middle">FK</text>
+  </switch>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:142px;height:1px;padding-top:353px;margin-left:473px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+            team_id
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="473" y="357" font-family="Helvetica" font-size="12">team_id</text>
+  </switch>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:142px;height:1px;padding-top:383px;margin-left:473px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+            start_date
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="473" y="387" font-family="Helvetica" font-size="12">start_date</text>
+  </switch>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:142px;height:1px;padding-top:413px;margin-left:473px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+            end_date
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="473" y="417" font-family="Helvetica" font-size="12">end_date</text>
+  </switch>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:142px;height:1px;padding-top:443px;margin-left:473px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+            description
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="473" y="447" font-family="Helvetica" font-size="12">description</text>
+  </switch>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:142px;height:1px;padding-top:473px;margin-left:473px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+            return_description
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="473" y="477" font-family="Helvetica" font-size="12">return_description</text>
+  </switch>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:142px;height:1px;padding-top:503px;margin-left:473px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+            restituted
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="473" y="507" font-family="Helvetica" font-size="12">restituted</text>
+  </switch>
+  <path d="M200 149v-30h180v30" fill="#FFF" stroke="#000" stroke-miterlimit="10" pointer-events="none"/>
+  <path d="M200 149v60h180v-60m-180 0h180m-120 0v60" fill="none" stroke="#000" stroke-miterlimit="10" pointer-events="none"/>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:178px;height:1px;padding-top:134px;margin-left:201px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;font-weight:700;white-space:normal;overflow-wrap:normal">
+            Item-Borrow
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="290" y="138" font-family="Helvetica" font-size="12" text-anchor="middle" font-weight="bold">Item-Borrow</text>
+  </switch>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:58px;height:1px;padding-top:164px;margin-left:201px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;font-weight:700;white-space:normal;overflow-wrap:normal">
+            PK,FK1
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="230" y="168" font-family="Helvetica" font-size="12" text-anchor="middle" font-weight="bold">PK,FK1</text>
+  </switch>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:112px;height:1px;padding-top:164px;margin-left:268px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;font-weight:700;text-decoration:underline;white-space:normal;overflow-wrap:normal">
+            item_id
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="268" y="168" font-family="Helvetica" font-size="12" font-weight="bold" text-decoration="underline">item_id</text>
+  </switch>
+  <path d="M380 209H200m0 0" fill="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10" pointer-events="none"/>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:58px;height:1px;padding-top:194px;margin-left:201px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;font-weight:700;white-space:normal;overflow-wrap:normal">
+            PK,FK2
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="230" y="198" font-family="Helvetica" font-size="12" text-anchor="middle" font-weight="bold">PK,FK2</text>
+  </switch>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:112px;height:1px;padding-top:194px;margin-left:268px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;font-weight:700;text-decoration:underline;white-space:normal;overflow-wrap:normal">
+            borrow_id
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="268" y="198" font-family="Helvetica" font-size="12" font-weight="bold" text-decoration="underline">borrow_id</text>
+  </switch>
+  <path d="M50 289v-30h180v30" fill="#FFF" stroke="#000" stroke-miterlimit="10" pointer-events="none"/>
+  <path d="M50 289v120h180V289m-180 0h180m-150 0v120" fill="none" stroke="#000" stroke-miterlimit="10" pointer-events="none"/>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:274px;margin-left:140px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;font-weight:700;white-space:nowrap">
+            Item
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="140" y="278" font-family="Helvetica" font-size="12" text-anchor="middle" font-weight="bold">Item</text>
+  </switch>
+  <path d="M230 319H50m0 0" fill="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10" pointer-events="none"/>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:28px;height:1px;padding-top:304px;margin-left:51px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;font-weight:700;white-space:normal;overflow-wrap:normal">
+            PK
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="65" y="308" font-family="Helvetica" font-size="12" text-anchor="middle" font-weight="bold">PK</text>
+  </switch>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:142px;height:1px;padding-top:304px;margin-left:88px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;font-weight:700;text-decoration:underline;white-space:normal;overflow-wrap:normal">
+            id
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="88" y="308" font-family="Helvetica" font-size="12" font-weight="bold" text-decoration="underline">id</text>
+  </switch>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:28px;height:1px;padding-top:334px;margin-left:51px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+            FK
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="65" y="338" font-family="Helvetica" font-size="12" text-anchor="middle">FK</text>
+  </switch>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:142px;height:1px;padding-top:334px;margin-left:88px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+            category_id
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="88" y="338" font-family="Helvetica" font-size="12">category_id</text>
+  </switch>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:142px;height:1px;padding-top:364px;margin-left:88px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+            name
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="88" y="368" font-family="Helvetica" font-size="12">name</text>
+  </switch>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:142px;height:1px;padding-top:394px;margin-left:88px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+            state
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="88" y="398" font-family="Helvetica" font-size="12">state</text>
+  </switch>
+  <path d="M380 639v-30h180v30" fill="#FFF" stroke="#000" stroke-miterlimit="10" pointer-events="none"/>
+  <path d="M380 639v120h180V639m-180 0h180m-150 0v120" fill="none" stroke="#000" stroke-miterlimit="10" pointer-events="none"/>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:624px;margin-left:470px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;font-weight:700;white-space:nowrap">
+            Room
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="470" y="628" font-family="Helvetica" font-size="12" text-anchor="middle" font-weight="bold">Room</text>
+  </switch>
+  <path d="M560 669H380m0 0" fill="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10" pointer-events="none"/>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:28px;height:1px;padding-top:654px;margin-left:381px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;font-weight:700;white-space:normal;overflow-wrap:normal">
+            PK
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="395" y="658" font-family="Helvetica" font-size="12" text-anchor="middle" font-weight="bold">PK</text>
+  </switch>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:142px;height:1px;padding-top:654px;margin-left:418px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;font-weight:700;text-decoration:underline;white-space:normal;overflow-wrap:normal">
+            id
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="418" y="658" font-family="Helvetica" font-size="12" font-weight="bold" text-decoration="underline">id</text>
+  </switch>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:142px;height:1px;padding-top:684px;margin-left:418px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+            name
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="418" y="688" font-family="Helvetica" font-size="12">name</text>
+  </switch>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:142px;height:1px;padding-top:714px;margin-left:418px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+            description
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="418" y="718" font-family="Helvetica" font-size="12">description</text>
+  </switch>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:142px;height:1px;padding-top:744px;margin-left:418px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+            reserved
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="418" y="748" font-family="Helvetica" font-size="12">reserved</text>
+  </switch>
+  <path d="M720 539v-30h180v30" fill="#FFF" stroke="#000" stroke-miterlimit="10" pointer-events="none"/>
+  <path d="M720 539v60h180v-60m-180 0h180m-150 0v60" fill="none" stroke="#000" stroke-miterlimit="10" pointer-events="none"/>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:524px;margin-left:810px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;font-weight:700;white-space:nowrap">
+            Group
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="810" y="528" font-family="Helvetica" font-size="12" text-anchor="middle" font-weight="bold">Group</text>
+  </switch>
+  <path d="M900 569H720m0 0" fill="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10" pointer-events="none"/>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:28px;height:1px;padding-top:554px;margin-left:721px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;font-weight:700;white-space:normal;overflow-wrap:normal">
+            PK
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="735" y="558" font-family="Helvetica" font-size="12" text-anchor="middle" font-weight="bold">PK</text>
+  </switch>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:142px;height:1px;padding-top:554px;margin-left:758px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;font-weight:700;text-decoration:underline;white-space:normal;overflow-wrap:normal">
+            id
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="758" y="558" font-family="Helvetica" font-size="12" font-weight="bold" text-decoration="underline">id</text>
+  </switch>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:142px;height:1px;padding-top:584px;margin-left:758px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+            name
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="758" y="588" font-family="Helvetica" font-size="12">name</text>
+  </switch>
+  <path d="M710 99V69h180v30" fill="#FFF" stroke="#000" stroke-miterlimit="10" pointer-events="none"/>
+  <path d="M710 99v210h180V99m-180 0h180m-150 0v210" fill="none" stroke="#000" stroke-miterlimit="10" pointer-events="none"/>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:84px;margin-left:800px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;font-weight:700;white-space:nowrap">
+            User
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="800" y="88" font-family="Helvetica" font-size="12" text-anchor="middle" font-weight="bold">User</text>
+  </switch>
+  <path d="M890 129H710m0 0" fill="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10" pointer-events="none"/>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:28px;height:1px;padding-top:114px;margin-left:711px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;font-weight:700;white-space:normal;overflow-wrap:normal">
+            PK
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="725" y="118" font-family="Helvetica" font-size="12" text-anchor="middle" font-weight="bold">PK</text>
+  </switch>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:142px;height:1px;padding-top:114px;margin-left:748px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;font-weight:700;text-decoration:underline;white-space:normal;overflow-wrap:normal">
+            id
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="748" y="118" font-family="Helvetica" font-size="12" font-weight="bold" text-decoration="underline">id</text>
+  </switch>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:142px;height:1px;padding-top:144px;margin-left:748px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+            email
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="748" y="148" font-family="Helvetica" font-size="12">email</text>
+  </switch>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:142px;height:1px;padding-top:174px;margin-left:748px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+            roles
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="748" y="178" font-family="Helvetica" font-size="12">roles</text>
+  </switch>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:142px;height:1px;padding-top:204px;margin-left:748px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+            password
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="748" y="208" font-family="Helvetica" font-size="12">password</text>
+  </switch>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:142px;height:1px;padding-top:234px;margin-left:748px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+            last_naùe
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="748" y="238" font-family="Helvetica" font-size="12">last_naùe</text>
+  </switch>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:142px;height:1px;padding-top:264px;margin-left:748px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+            first_name
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="748" y="268" font-family="Helvetica" font-size="12">first_name</text>
+  </switch>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:142px;height:1px;padding-top:294px;margin-left:748px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+            is_verified
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="748" y="298" font-family="Helvetica" font-size="12">is_verified</text>
+  </switch>
+  <path d="M940 410v-30h180v30" fill="#FFF" stroke="#000" stroke-miterlimit="10" pointer-events="none"/>
+  <path d="M940 410v60h180v-60m-180 0h180m-120 0v60" fill="none" stroke="#000" stroke-miterlimit="10" pointer-events="none"/>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:178px;height:1px;padding-top:395px;margin-left:941px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;font-weight:700;white-space:normal;overflow-wrap:normal">
+            Group-User
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="1030" y="399" font-family="Helvetica" font-size="12" text-anchor="middle" font-weight="bold">Group-User</text>
+  </switch>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:58px;height:1px;padding-top:425px;margin-left:941px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;font-weight:700;white-space:normal;overflow-wrap:normal">
+            PK,FK1
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="970" y="429" font-family="Helvetica" font-size="12" text-anchor="middle" font-weight="bold">PK,FK1</text>
+  </switch>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:112px;height:1px;padding-top:425px;margin-left:1008px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;font-weight:700;text-decoration:underline;white-space:normal;overflow-wrap:normal">
+            group_id
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="1008" y="429" font-family="Helvetica" font-size="12" font-weight="bold" text-decoration="underline">group_id</text>
+  </switch>
+  <path d="M1120 470H940m0 0" fill="none" stroke="#000" stroke-linecap="square" stroke-miterlimit="10" pointer-events="none"/>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:58px;height:1px;padding-top:455px;margin-left:941px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;font-weight:700;white-space:normal;overflow-wrap:normal">
+            PK,FK2
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="970" y="459" font-family="Helvetica" font-size="12" text-anchor="middle" font-weight="bold">PK,FK2</text>
+  </switch>
+  <switch>
+    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:112px;height:1px;padding-top:455px;margin-left:1008px">
+        <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left;max-height:26px;overflow:hidden">
+          <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;font-weight:700;text-decoration:underline;white-space:normal;overflow-wrap:normal">
+            user_id
+          </div>
+        </div>
+      </div>
+    </foreignObject>
+    <text x="1008" y="459" font-family="Helvetica" font-size="12" font-weight="bold" text-decoration="underline">user_id</text>
+  </switch>
+  <path d="M435 323H310v324h70m235-294h53v201h52M380 194h28v69h27M50 304H40V164h160M50 334H40v200h10m1070-109h10v129H900M615 293h48V114h47m180 0h25v341h25" fill="none" stroke="#000" stroke-miterlimit="10" pointer-events="none"/>
+  <switch>
+    <a transform="translate(0 -5)" xlink:href="https://www.drawio.com/doc/faq/svg-export-text-problems" target="_blank">
+      <text text-anchor="middle" font-size="10" x="50%" y="100%">Text is not SVG - cannot display</text>
+    </a>
+  </switch>
 </svg>
+

--- a/doc/référence/modèle.md
+++ b/doc/référence/modèle.md
@@ -1,7 +1,7 @@
 Modèle d'objets
 ===============
 
-Nous avons défini différentes  entités pour constituer le modèle :
+Nous avons défini différentes entités pour constituer le modèle :
 
  - Catégories
  - Objets
@@ -9,3 +9,30 @@ Nous avons défini différentes  entités pour constituer le modèle :
  - Groupes
  - Utilisateurs
  - Emprunts
+
+
+Emprunts
+--------
+Les emprunts modélisent les emprunts des élèves, leurs réservations.
+
+$id (int) : L'identifiant de l'objet dans la base de données.
+
+$startDate (DateTimeImmutable) : La date de début de l'emprunt. Cette date de
+fin doit nécessairement être postérieure ou égale à la date de début.
+
+$endDate (DateTimeImmutable) : La date de fin de l'emprunt.
+
+$description (string) : La description de l'emprunt, son utilisation.
+
+$returnDescription (string) : La description de l'emprunt lors de son retour.
+
+$restituted (boolean) = false : Si l'emprunt a été clôturé et les items rendus.
+Faux par défaut.
+
+$stakeholder (User): L'utilisateur responsable de l'emprunt.
+
+$room (Room) : La salle dans laquelle les items empruntés sont utilisés.
+
+$items (Collection d'items) : Les items empruntés.
+
+$team (Group) : Le groupe réalisant l'emprunt.

--- a/project/migrations/Version20230521195657.php
+++ b/project/migrations/Version20230521195657.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20230521195657 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return "Remove the unused 'quantity' attribute of borrows.";
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE borrow DROP quantity');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE borrow ADD quantity INT NOT NULL');
+    }
+}

--- a/project/src/Controller/BorrowController.php
+++ b/project/src/Controller/BorrowController.php
@@ -31,12 +31,15 @@ class BorrowController extends AbstractController
 
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {
-            $repo->add($form->getData(), true);
-            
+            foreach ($form->get("items")->getData() as $item) {
+                $borrow->addItem($item);
+            }
+            $repo->add($borrow, true);
+
             return $this->redirectToRoute('app_borrow');
         }
 
-        return $this->render('borrow/add.html.twig',[
+        return $this->render('borrow/add.html.twig', [
             'form' => $form->createView()
         ]);
     }

--- a/project/src/DataFixtures/AppFixtures.php
+++ b/project/src/DataFixtures/AppFixtures.php
@@ -107,8 +107,7 @@ class AppFixtures extends Fixture
             ->setTeam($groups[$i])
             ->addItem($items[$i % sizeof($items)])
             ->addItem($items[($i + 1) % sizeof($items)])
-            ->addItem($items[($i + 2) % sizeof($items)])
-            ->setQuantity($faker->numberBetween($min = 5, $max = 214));
+            ->addItem($items[($i + 2) % sizeof($items)]);
             $entityManager->persist($borrows[$i]);
         }
         

--- a/project/src/Entity/Borrow.php
+++ b/project/src/Entity/Borrow.php
@@ -6,6 +6,7 @@ use App\Repository\BorrowRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: BorrowRepository::class)]
 class Borrow
@@ -16,9 +17,15 @@ class Borrow
     private $id;
 
     #[ORM\Column(type: 'date')]
+    #[Assert\Type(\DateTimeImmutable::class)]
     private $startDate;
 
     #[ORM\Column(type: 'date', nullable: true)]
+    #[Assert\Type(\DateTimeImmutable::class)]
+    #[Assert\Expression(
+        expression: "this.getStartDate() <= this.getEndDate()",
+        message: "La date de fin doit être postérieure à la date de début.",
+    )]
     private $endDate;
 
     #[ORM\Column(type: 'text', nullable: true)]

--- a/project/src/Entity/Borrow.php
+++ b/project/src/Entity/Borrow.php
@@ -37,9 +37,6 @@ class Borrow
     #[ORM\Column(type: 'boolean')]
     private $restituted = false;
 
-    #[ORM\Column(type: 'integer')]
-    private $quantity;
-
     #[ORM\ManyToOne(inversedBy: 'borrows')]
     #[ORM\JoinColumn(nullable: false)]
     private ?User $stakeholder = null;
@@ -122,20 +119,6 @@ class Borrow
 
         return $this;
     }
-
-    public function getQuantity(): ?int
-    {
-        return $this->quantity;
-    }
-
-    public function setQuantity(int $quantity): self
-    {
-        $this->quantity = $quantity;
-
-        return $this;
-    }
-
-
 
     public function getStakeholder(): ?User
     {

--- a/project/src/Entity/Borrow.php
+++ b/project/src/Entity/Borrow.php
@@ -39,16 +39,16 @@ class Borrow
 
     #[ORM\ManyToOne(inversedBy: 'borrows')]
     #[ORM\JoinColumn(nullable: false)]
-    private ?User $stakeholder = null;
+    private User $stakeholder;
 
     #[ORM\ManyToOne(inversedBy: 'borrows')]
-    private ?Room $room = null;
+    private Room $room;
 
     #[ORM\ManyToMany(targetEntity: Item::class, mappedBy: 'borrow')]
     private Collection $items;
 
     #[ORM\ManyToOne(inversedBy: 'borrows')]
-    private ?Group $team = null;
+    private Group $team;
 
     public function __construct()
     {
@@ -120,24 +120,24 @@ class Borrow
         return $this;
     }
 
-    public function getStakeholder(): ?User
+    public function getStakeholder(): User
     {
         return $this->stakeholder;
     }
 
-    public function setStakeholder(?User $stakeholder): self
+    public function setStakeholder(User $stakeholder): self
     {
         $this->stakeholder = $stakeholder;
 
         return $this;
     }
 
-    public function getRoom(): ?Room
+    public function getRoom(): Room
     {
         return $this->room;
     }
 
-    public function setRoom(?Room $room): self
+    public function setRoom(Room $room): self
     {
         $this->room = $room;
 
@@ -171,12 +171,12 @@ class Borrow
         return $this;
     }
 
-    public function getTeam(): ?Group
+    public function getTeam(): Group
     {
         return $this->team;
     }
 
-    public function setTeam(?Group $team): self
+    public function setTeam(Group $team): self
     {
         $this->team = $team;
 

--- a/project/src/Form/BorrowType.php
+++ b/project/src/Form/BorrowType.php
@@ -64,7 +64,9 @@ class BorrowType extends AbstractType
             ])
             ->add('items', EntityType::class, [
                 'required' => true,
+                "multiple" => true,
                 'class' => Item::class,
+                "help" => "Utilisez la touche contrôle pour sélectionner plusieurs objets.",
                 'query_builder' => function (EntityRepository $repository) {
                     return $repository->createQueryBuilder('items')
                         ->select('items')

--- a/project/src/Form/BorrowType.php
+++ b/project/src/Form/BorrowType.php
@@ -26,7 +26,9 @@ class BorrowType extends AbstractType
             ->add('description',TextType::class,['required' => true])
             ->add('quantity',NumberType::class,['required' => true])
             ->add('stakeholder', EntityType::class, [
-                'class' => User::class,'required' => true,
+                'class' => User::class,
+                'required' => true,
+                "placeholder" => "Choisissez un utilisateur",
                 // sort stakeholder by alphabetical order
                 'query_builder' => function (EntityRepository $repository) {
                     return $repository->createQueryBuilder('user')
@@ -40,6 +42,7 @@ class BorrowType extends AbstractType
             ->add('room', EntityType::class, [
                 'required' => true,
                 'class' => Room::class,
+                "placeholder" => "Choisissez une salle",
                 'query_builder' => function (EntityRepository $repository) {
                     return $repository->createQueryBuilder('room')
                         ->select('room')
@@ -65,6 +68,7 @@ class BorrowType extends AbstractType
             ->add('team', EntityType::class, [
                 'required' => true,
                 'class' => Group::class,
+                "placeholder" => "Choisissez une équipe",
                 'query_builder' => function (EntityRepository $repository) {
                     return $repository->createQueryBuilder('g')
                         ->select('g')

--- a/project/src/Form/BorrowType.php
+++ b/project/src/Form/BorrowType.php
@@ -21,8 +21,18 @@ class BorrowType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
-            ->add('startDate', DateType::class, ['data' => new \DateTime(),'required' => true])
-            ->add('endDate',DateType::class, ['required' => true])
+            ->add('startDate', DateType::class, [
+                'data' => new \DateTimeImmutable(),
+                'required' => true,
+                'input' => 'datetime_immutable',
+                'widget' => 'single_text',
+            ])
+            ->add('endDate', DateType::class, [
+                'data' => new \DateTimeImmutable(),
+                'required' => true,
+                'input' => 'datetime_immutable',
+                'widget' => 'single_text',
+            ])
             ->add('description',TextType::class,['required' => true])
             ->add('quantity',NumberType::class,['required' => true])
             ->add('stakeholder', EntityType::class, [

--- a/project/src/Form/BorrowType.php
+++ b/project/src/Form/BorrowType.php
@@ -14,7 +14,6 @@ use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
-use Symfony\Component\Form\Extension\Core\Type\NumberType;
 
 class BorrowType extends AbstractType
 {
@@ -33,8 +32,7 @@ class BorrowType extends AbstractType
                 'input' => 'datetime_immutable',
                 'widget' => 'single_text',
             ])
-            ->add('description',TextType::class,['required' => true])
-            ->add('quantity',NumberType::class,['required' => true])
+            ->add('description', TextType::class, ['required' => true])
             ->add('stakeholder', EntityType::class, [
                 'class' => User::class,
                 'required' => true,


### PR DESCRIPTION
Improve the robustness of the reservation creation interface.

- Check the dates' order
- Use the HTML date picker
- Allow selecting more than one item at a time
- Save the item borrowing in the database
- Use placeholders for drop-down menus, forcing a voluntary choice (the first item of the list would be selected otherwise)

Closes #71.