### PR TITLE
Fix #51: Enable email sending

### DIFF
--- a/doc/guides/configurer_envoi_courriels.md
+++ b/doc/guides/configurer_envoi_courriels.md
@@ -1,0 +1,43 @@
+Configurer l'envoi de courriels
+=================================
+
+L'application doit être configurée pour envoyer des courriels.
+
+L'envoi des courriels utilise le protocole [SMTP](https://fr.wikipedia.org/wiki/Simple_Mail_Transfer_Protocol), comme beaucoup de clients de courriel.
+
+Les paramètres de connexion SMTP sont indiqués dans la variable d'environnement
+`MAILER_DSN`.
+
+Comme il est nécessaire d'indiquer le mot de passe du compte, il ne faut pas
+partager cette configuration et la garder en local. Le fichier `.env.local` est
+adapté à cet usage.
+
+Voici un exemple de configuration, en utilisant les [paramètres pour un serveur
+Office365](https://support.microsoft.com/fr-fr/office/param%C3%A8tres-pop-imap-et-smtp-8361e398-8af4-4e97-b147-6c6c4ac95353).
+```sh
+EMAIL_ADDRESS="adresse@example.org"
+MAILER_DSN=smtp://${EMAIL_ADDRESS}:"###"@smtp.office365.com:587
+```
+
+La variable *MAILER_DSN* a la syntaxe suivante : `smtp://adresse:motdepasse@serveur:port`.
+
+Une fois le protocole configuré, des courriels peuvent être envoyés.
+
+Il est possible de configurer le client pour que les courriels ne soient pas
+envoyés directement, mais attendent de façon asynchrone dans une file d'attente.
+
+Pour les envoyer au serveur, il est alors nécessaire d'utiliser un
+*travailleur*, qui va consommer les messages en attente.
+
+En invoquer un simplement avec la ligne de commande se fait comme suit:
+```sh
+php bin/console messenger:consume async
+```
+
+Le travailleur enverra les messages en attente et ceux qui seront envoyés
+pendant son exécution.
+Le travailleur continuera à tourner en mode *démon* tant qu'il n'est pas arrêté.
+
+Il est possible d'automatiser le démarrage des travailleurs avec divers outils,
+ comme la documentation de Symfony l'indique sur [cette
+ page](https://symfony.com/doc/5.4/messenger.html#deploying-to-production).

--- a/project/.gitignore
+++ b/project/.gitignore
@@ -60,3 +60,5 @@
 /web/js/
 
 # End of https://www.toptal.com/developers/gitignore/api/symfony
+
+.env.local

--- a/project/src/Controller/MailerController.php
+++ b/project/src/Controller/MailerController.php
@@ -14,15 +14,17 @@ class MailerController extends AbstractController
     #[Route('/mail', name: 'app_mail')]
     public function index(MailerInterface $mailer): Response
     {
-        
+
+        $sender_email = $_ENV["EMAIL_ADDRESS"];
+
         $email = (new Email())
-            ->from('hello@example.com')
-            ->to('you@example.com')
-            ->subject('Test de MailDev')
-            ->text('Ceci est un mail de test');
+            ->from($sender_email)
+            ->to($sender_email)
+            ->subject('Test d\'envoi')
+            ->text('Ceci est un courriel envoyé depuis Symfony.');
         $mailer->send($email);
 
-        return $this->render('home/index.html.twig', [
+        return $this->render('mailer/index.html.twig', [
             'controller_name' => 'HomeController',
         ]);
     }

--- a/project/src/Controller/RegistrationController.php
+++ b/project/src/Controller/RegistrationController.php
@@ -44,16 +44,16 @@ class RegistrationController extends AbstractController
 
             $entityManager->persist($user);
             $entityManager->flush();
-            /*TODO 
             // generate a signed url and email it to the user
-            $this->emailVerifier->sendEmailConfirmation('app_verify_email', $user,
+            $this->emailVerifier->sendEmailConfirmation(
+                'app_verify_email',
+                $user,
                 (new TemplatedEmail())
-                    ->from(new Address('equipmentmanager@epf.fr', 'Equipment Manager Bot'))
+                    ->from(new Address($_ENV["EMAIL_ADDRESS"], 'Equipment Manager Bot')) // equipmentmanager@epf.fr
                     ->to($user->getEmail())
                     ->subject('Please Confirm your Email')
                     ->htmlTemplate('registration/confirmation_email.html.twig')
             );
-            */
 
             return $this->redirectToRoute('app_home');
         }
@@ -87,9 +87,8 @@ class RegistrationController extends AbstractController
             return $this->redirectToRoute('app_register');
         }
 
-        // @TODO Change the redirect on success and handle or remove the flash message in your templates
-        $this->addFlash('success', 'Your email address has been verified.');
-
-        return $this->redirectToRoute('app_register');
+        return $this->render('registration/verified.html.twig', [
+            'user' => $user,
+        ]);
     }
 }

--- a/project/templates/registration/verified.html.twig
+++ b/project/templates/registration/verified.html.twig
@@ -1,0 +1,14 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Votre adresse électronique est vérifiée{% endblock %}
+
+{% block body %}
+
+<h1>C'est validé, {{ user.firstName }}</h1>
+
+<p>Votre adresse électronique a été vérifiée. Vous pouvez à présent fermer cet
+onglet ou continuer votre navigation.</p>
+
+<a href="/">Aller à la page d'accueil</a>
+
+{% endblock %}


### PR DESCRIPTION
Enables the app to send address verification emails to users.

Sender email configuration should be set in the local environment, e.g. in `.env.local`.

Closes #51 and #50.